### PR TITLE
Add non-node wrapper so code works in a browser

### DIFF
--- a/xpath.js
+++ b/xpath.js
@@ -4283,7 +4283,7 @@ try {
 
 // ---------------------------------------------------------------------------
 // exports for node.js
-	
+
 installDOM3XPathSupport(exports, new XPathParser());
 
 exports.XPathResult = XPathResult;


### PR DESCRIPTION
Hi goto100,

This pull request has just some wrapper code so that `xpath.js` can be loaded in a browser and referenced by a global `xpath` var.
