### PR TITLE
"Namespaces" sample code in README won't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ xpath is xml engine agnostic but I recommend to use [xmldom](https://github.com/
 `````javascript
     var xml = "<book><title xmlns='myns'>Harry Potter</title></book>"
     var doc = new dom().parseFromString(xml)
-    var node = xpath.select("//*[local-name(.)='title' and namespace-uri(.)='myns/']", doc)[0]
+    var node = xpath.select("//*[local-name(.)='title' and namespace-uri(.)='myns']", doc)[0]
     console.log(node.namespaceURI)
 `````
 -->


### PR DESCRIPTION
In the last line of [the sample code of namespaces in README](https://github.com/goto100/xpath/blob/20ce534af81096b1c02cbdeb676ad58231a52ed7/README.md), `TypeError: Cannot read property 'namespaceURI' of undefined` is thrown because `xpath.select(...)` returns an empty array.

Replacing `"myns/"` with `"myns" in the XPath, it works as expected.