### PR TITLE
Fixed XPathNamespace instantiation

### DIFF
--- a/xpath.js
+++ b/xpath.js
@@ -1878,7 +1878,7 @@ PathExpr.prototype.evaluate = function(c) {
 								}
 							}
 							for (var pre in n) {
-								var nsn = new NamespaceNode(pre, n[pre], xpc.contextNode);
+								var nsn = new XPathNamespace(pre, n[pre], xpc.contextNode);
 								if (step.nodeTest.matches(nsn, xpc)) {
 									newNodes.push(nsn);
 								}


### PR DESCRIPTION
The code is referencing a non-existing class `NamespaceNode` for instantiating namespace nodes. Instead, it should use the correct class name `XPathNamespace`.

Please merge this and release an updated nmp module. Thanks a bunch! :)
