### PR TITLE
Fix license specification in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "xpath",
     "xml"
   ],
-  "license": "Creative Commons"
+  "license": "CC-BY-4.0"
 }
 


### PR DESCRIPTION
"Creative Commons" is a *class* of licenses rather than a specific license; this changes the license to the correct SPDX specification that matches the LICENSE file in the repository.