### PR TITLE
Update TypeScript definitions for strict null checks

### DIFF
--- a/xpath.d.ts
+++ b/xpath.d.ts
@@ -1,9 +1,9 @@
 type SelectedValue = Node | Attr | string | number | boolean;
 interface XPathSelect {
     (expression: string, node?: Node): Array<SelectedValue>;
-    (expression: string, node: Node, single: true): SelectedValue;
+    (expression: string, node: Node, single: true): SelectedValue | undefined;
 }
 export var select: XPathSelect;
-export function select1(expression: string, node?: Node): SelectedValue;
-export function evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver, type: number, result: XPathResult): XPathResult;
+export function select1(expression: string, node?: Node): SelectedValue | undefined;
+export function evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | null, type: number, result: XPathResult | null): XPathResult;
 export function useNamespaces(namespaceMap: { [name: string]: string }): XPathSelect;


### PR DESCRIPTION
TypeScript 2 introduces the `strictNullChecks` mode, which won't accept `null`/`undefined` values unless they are specifically declared. This is a slight change to reflect where these values are accepted and returned.