### PR TITLE
Fix type of parameter 'single' of XPathSelect interface

### DIFF
--- a/xpath.d.ts
+++ b/xpath.d.ts
@@ -1,7 +1,7 @@
 type SelectedValue = Node | Attr | string | number | boolean;
 interface XPathSelect {
     (expression: string, node?: Node): Array<SelectedValue>;
-    (expression: string, node: Node, single: true): SelectedValue;
+    (expression: string, node: Node, single: boolean): SelectedValue;
 }
 export var select: XPathSelect;
 export function select1(expression: string, node?: Node): SelectedValue;


### PR DESCRIPTION
Fix the incorrect type of parameter 'single' to boolean (was set to 'true')