### PR TITLE
Revert "Fix type of parameter 'single' of XPathSelect interface"

### DIFF
--- a/xpath.d.ts
+++ b/xpath.d.ts
@@ -3,7 +3,7 @@
 type SelectedValue = Node | Attr | string | number | boolean;
 interface XPathSelect {
     (expression: string, node?: Node): Array<SelectedValue>;
-    (expression: string, node: Node, single: boolean): SelectedValue;
+    (expression: string, node: Node, single: true): SelectedValue;
 }
 export var select: XPathSelect;
 export function select1(expression: string, node?: Node): SelectedValue;


### PR DESCRIPTION
Reverts goto100/xpath#84

After looking at this more closely, it looks like the type of `true` on single was intentional to distinguish it from the version of the method without `single`. Reverting this until a better resolution can be found.