### PR TITLE
Fix issue with RangeError called on concat.apply()

### DIFF
--- a/xpath.js
+++ b/xpath.js
@@ -166,9 +166,17 @@ var xpath = (typeof exports === 'undefined') ? {} : exports;
     var wrap = function (pref, suf, str) { return pref + str + suf; };
 
     var prototypeConcat = Array.prototype.concat;
+    var prototypeSlice = Array.prototype.slice;
+    var MAX_ARGUMENT_LENGTH = 32767;
 
     function flatten(arr) {
-        return prototypeConcat.apply([], arr);
+        var result = [];
+        for (var start = 0; start < arr.length; start += MAX_ARGUMENT_LENGTH) {
+            var end = Math.min(start + MAX_ARGUMENT_LENGTH, arr.length);
+            var chunk = prototypeSlice.call(arr, start, end);
+            result = prototypeConcat.apply(result, chunk);
+        }
+        return result
     }
 
     function assign(target, varArgs) { // .length of function is 2


### PR DESCRIPTION
When calling the flatten function with a sufficiently large array it
will throw: RangeError: Maximum call stack size exceeded

This was found when processing very large xml documents and using a //
selector in select().

This is due to the maximum argument length limit in javascript/node.
Calling apply() with a sufficiently large array will throw a RangeError.
See https://bugs.webkit.org/show_bug.cgi?id=80797 for details.

Iterate over the array and recursively push items onto the result array.
This also will flatten an array of arbitrary depth.