### PR TITLE
Replace unshift where possible for performance improvement

### DIFF
--- a/xpath.js
+++ b/xpath.js
@@ -268,7 +268,8 @@ var xpath = (typeof exports === 'undefined') ? {} : exports;
         };
         this.reduceActions[28] = function (rhs) {
             rhs[0].locationPath = rhs[2];
-            rhs[0].locationPath.steps.unshift(new Step(Step.DESCENDANTORSELF, NodeTest.nodeTest, []));
+            rhs[0].locationPath.steps.push(new Step(Step.DESCENDANTORSELF, NodeTest.nodeTest, []));
+            rhs[0].locationPath.steps.reverse();
             return rhs[0];
         };
         this.reduceActions[29] = function (rhs) {
@@ -1260,9 +1261,10 @@ var xpath = (typeof exports === 'undefined') ? {} : exports;
                     var rhs = [];
                     for (var i = 0; i < num; i++) {
                         tokenType.pop();
-                        rhs.unshift(tokenValue.pop());
+                        rhs.push(tokenValue.pop());
                         state.pop();
                     }
+                    rhs.reverse();
                     var s_ = state[state.length - 1];
                     tokenType.push(XPathParser.productions[XPathParser.actionTableNumber[s].charCodeAt(a - 1) - 32][0]);
                     if (this.reduceActions[XPathParser.actionTableNumber[s].charCodeAt(a - 1) - 32] == undefined) {
@@ -1930,13 +1932,14 @@ var xpath = (typeof exports === 'undefined') ? {} : exports;
                 }
                 var st = [];
                 if (xpc.contextNode.firstChild != null) {
-                    st.unshift(xpc.contextNode.firstChild);
+                    st.push(xpc.contextNode.firstChild);
                 } else {
-                    st.unshift(xpc.contextNode.nextSibling);
+                    st.push(xpc.contextNode.nextSibling);
                 }
                 for (var m = xpc.contextNode.parentNode; m != null && m.nodeType != 9 /*Node.DOCUMENT_NODE*/ && m !== xpc.virtualRoot; m = m.parentNode) {
-                    st.unshift(m.nextSibling);
+                    st.push(m.nextSibling);
                 }
+                st.reverse();
                 do {
                     for (var m = st.pop(); m != null;) {
                         if (step.nodeTest.matches(m, xpc)) {
@@ -2021,7 +2024,8 @@ var xpath = (typeof exports === 'undefined') ? {} : exports;
                             break outer;
                         }
                         if (step.nodeTest.matches(m, xpc)) {
-                            newNodes.unshift(m);
+                            newNodes.push(m);
+                            newNodes.reverse();
                         }
                         if (m.firstChild != null) {
                             st.push(m.nextSibling);


### PR DESCRIPTION
Found this when debugging an application I wrote that needs to query some 50-60MB XML files. Using the Chrome Dev tools CPU profiler I identified one of the longest calls was on `.unshift()`, following some of the suggestions in this [post](https://stackoverflow.com/questions/44031591/performance-of-array-push-vs-array-unshift) I replaced the unshift calls that I could with .push() and .reverse(). Seemed to make a marked improvement in the CPU profiler report in that area.

Tests are still passing.

CPU Profile Before (17630ms on `res.unshift(tokenValue.pop())` ) :

<img width="891" alt="image" src="https://user-images.githubusercontent.com/60047271/128844034-b2a081eb-04e1-41b5-a8af-443bd85e44bf.png">


CPU Profile After ( `push()` and `reverse()` calls are around ~6200ms, down from 17630ms call to `unshift()` )  :

<img width="872" alt="image" src="https://user-images.githubusercontent.com/60047271/128845028-d4bc822a-1967-4562-b1f5-69819848d8a0.png">


