### PR TITLE
changed install command for xmldom in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install with [npm](http://github.com/isaacs/npm):
 
 xpath is xml engine agnostic but we recommend [xmldom](https://github.com/xmldom/xmldom):
 
-    npm install xmldom
+    npm install @xmldom/xmldom
 
 ## API Documentation
 


### PR DESCRIPTION
xmldom is no longer published on NPM, but now published from their github repo.

see their issue for more info here:
https://github.com/xmldom/xmldom/issues/271