### PR TITLE
Append `Node` to check functions; refactor

### DIFF
--- a/test.js
+++ b/test.js
@@ -1058,8 +1058,8 @@ describe('xpath', () => {
             var element = doc.createElement('characters');
 
             assert.ok(xpath.isNodeLike(element));
-            assert.ok(xpath.isElement(element));
-            assert.ok(!xpath.isAttribute(doc));
+            assert.ok(xpath.isElementNode(element));
+            assert.ok(!xpath.isAttributeNode(doc));
         });
 
         it('should correctly identify a Node of type Attribute', () => {
@@ -1067,7 +1067,7 @@ describe('xpath', () => {
             var attribute = doc.createAttribute('name');
 
             assert.ok(xpath.isNodeLike(attribute));
-            assert.ok(xpath.isAttribute(attribute));
+            assert.ok(xpath.isAttributeNode(attribute));
             assert.ok(!xpath.isTextNode(attribute));
         });
 
@@ -1077,7 +1077,7 @@ describe('xpath', () => {
 
             assert.ok(xpath.isNodeLike(text));
             assert.ok(xpath.isTextNode(text));
-            assert.ok(!xpath.isCDATASection(text));
+            assert.ok(!xpath.isCDATASectionNode(text));
         });
 
         it('should correctly identify a Node of type CDATASection', () => {
@@ -1085,18 +1085,17 @@ describe('xpath', () => {
             var cdata = doc.createCDATASection('Harry Potter');
 
             assert.ok(xpath.isNodeLike(cdata));
-            assert.ok(xpath.isCDATASection(cdata));
-            assert.ok(!xpath.isProcessingInstruction(cdata));
+            assert.ok(xpath.isCDATASectionNode(cdata));
+            assert.ok(!xpath.isProcessingInstructionNode(cdata));
         });
 
         it('should correctly identify a Node of type ProcessingInstruction', () => {
             var doc = parseXml('<book />');
             var pi = doc.createProcessingInstruction('xml-stylesheet', 'href="mycss.css" type="text/css"');
 
-            // This test fails due to a bug in @xmldom/xmldom@0.8.8
-            // assert.ok(xpath.isNodeLike(pi));
-            assert.ok(xpath.isProcessingInstruction(pi));
-            assert.ok(!xpath.isComment(pi));
+            assert.ok(xpath.isNodeLike(pi));
+            assert.ok(xpath.isProcessingInstructionNode(pi));
+            assert.ok(!xpath.isCommentNode(pi));
         });
 
         it('should correctly identify a Node of type Comment', () => {
@@ -1104,7 +1103,7 @@ describe('xpath', () => {
             var comment = doc.createComment('Harry Potter');
 
             assert.ok(xpath.isNodeLike(comment));
-            assert.ok(xpath.isComment(comment));
+            assert.ok(xpath.isCommentNode(comment));
             assert.ok(!xpath.isDocumentNode(comment));
         });
 
@@ -1122,7 +1121,7 @@ describe('xpath', () => {
 
             assert.ok(xpath.isNodeLike(doctype));
             assert.ok(xpath.isDocumentTypeNode(doctype));
-            assert.ok(!xpath.isDocumentFragment(doctype));
+            assert.ok(!xpath.isDocumentFragmentNode(doctype));
         });
 
         it('should correctly identify a Node of type DocumentFragment', () => {
@@ -1130,8 +1129,8 @@ describe('xpath', () => {
             var fragment = doc.createDocumentFragment();
 
             assert.ok(xpath.isNodeLike(fragment));
-            assert.ok(xpath.isDocumentFragment(fragment));
-            assert.ok(!xpath.isElement(fragment));
+            assert.ok(xpath.isDocumentFragmentNode(fragment));
+            assert.ok(!xpath.isElementNode(fragment));
         });
 
         it('should not identify a string as a Node', () => {

--- a/xpath.d.ts
+++ b/xpath.d.ts
@@ -5,6 +5,8 @@ export type ScalarValue = string | number | boolean;
 export type SelectReturnType = Array<Node> | ScalarValue;
 export type SelectSingleReturnType = ScalarValue | Node | undefined;
 
+type Nullable<T> = T | null
+
 export interface XPathSelect {
     (expression: string, node: Node): SelectReturnType;
     (expression: string, node: Node, single: false): SelectReturnType;
@@ -38,14 +40,14 @@ export function selectWithResolver(expression: string, node: Node, resolver: XPa
 export function useNamespaces(namespaceMap: Record<string, string>): XPathSelect;
 
 // Type guards to narrow down the type of the selected type of a returned Node object
-export function isNodeLike(value: SelectSingleReturnType): value is Node;
-export function isArrayOfNodes(value: SelectReturnType): value is Node[];
-export function isElement(value: SelectSingleReturnType): value is Element;
-export function isAttribute(value: SelectSingleReturnType): value is Attr;
-export function isTextNode(value: SelectSingleReturnType): value is Text;
-export function isCDATASection(value: SelectSingleReturnType): value is CDATASection;
-export function isProcessingInstruction(value: SelectSingleReturnType): value is ProcessingInstruction;
-export function isComment(value: SelectSingleReturnType): value is Comment;
-export function isDocumentNode(value: SelectSingleReturnType): value is Document;
-export function isDocumentTypeNode(value: SelectSingleReturnType): value is DocumentType;
-export function isDocumentFragment(value: SelectSingleReturnType): value is DocumentFragment;
+export function isNodeLike(value: Nullable<SelectSingleReturnType>): value is Node;
+export function isArrayOfNodes(value: Nullable<SelectReturnType>): value is Node[];
+export function isElementNode(value: Nullable<SelectSingleReturnType>): value is Element;
+export function isAttributeNode(value: Nullable<SelectSingleReturnType>): value is Attr;
+export function isTextNode(value: Nullable<SelectSingleReturnType>): value is Text;
+export function isCDATASectionNode(value: Nullable<SelectSingleReturnType>): value is CDATASection;
+export function isProcessingInstructionNode(value: Nullable<SelectSingleReturnType>): value is ProcessingInstruction;
+export function isCommentNode(value: Nullable<SelectSingleReturnType>): value is Comment;
+export function isDocumentNode(value: Nullable<SelectSingleReturnType>): value is Document;
+export function isDocumentTypeNode(value: Nullable<SelectSingleReturnType>): value is DocumentType;
+export function isDocumentFragmentNode(value: Nullable<SelectSingleReturnType>): value is DocumentFragment;

--- a/xpath.js
+++ b/xpath.js
@@ -3099,8 +3099,8 @@ var xpath = (typeof exports === 'undefined') ? {} : exports;
             n2Par = n2.parentNode || n2.ownerElement;
         }
 
-        var n1isAttr = Utilities.isAttribute(n1);
-        var n2isAttr = Utilities.isAttribute(n2);
+        var n1isAttr = Utilities.isAttributeNode(n1);
+        var n2isAttr = Utilities.isAttributeNode(n2);
 
         if (n1isAttr && !n2isAttr) {
             return -1;
@@ -3912,9 +3912,36 @@ var xpath = (typeof exports === 'undefined') ? {} : exports;
 
     var Utilities = new Object();
 
-    Utilities.isAttribute = function (val) {
-        return val && (val.nodeType === NodeTypes.ATTRIBUTE_NODE || val.ownerElement);
-    }
+    Utilities.isNodeLike = function (value) {
+        return value 
+            && typeof value.nodeType === "number" 
+            && Number.isInteger(value.nodeType)
+            && value.nodeType >= 1
+            && value.nodeType <= 11
+            && typeof value.nodeName === "string"
+            && typeof value.appendChild === "function"
+            && typeof value.removeChild === "function";
+    };
+
+    Utilities.isArrayOfNodes = function (value) {
+        return Array.isArray(value) && value.every(Utilities.isNodeLike);
+    };
+
+    Utilities.isNodeOfType = function (type) {
+        return function (value) {
+            return Utilities.isNodeLike(value) && value.nodeType === type;
+        };
+    };
+
+    Utilities.isElementNode = Utilities.isNodeOfType(NodeTypes.ELEMENT_NODE),
+    Utilities.isAttributeNode = Utilities.isNodeOfType(NodeTypes.ATTRIBUTE_NODE),
+    Utilities.isTextNode = Utilities.isNodeOfType(NodeTypes.TEXT_NODE),
+    Utilities.isCDATASectionNode = Utilities.isNodeOfType(NodeTypes.CDATA_SECTION_NODE),
+    Utilities.isProcessingInstructionNode = Utilities.isNodeOfType(NodeTypes.PROCESSING_INSTRUCTION_NODE),
+    Utilities.isCommentNode = Utilities.isNodeOfType(NodeTypes.COMMENT_NODE),
+    Utilities.isDocumentNode = Utilities.isNodeOfType(NodeTypes.DOCUMENT_NODE),
+    Utilities.isDocumentTypeNode = Utilities.isNodeOfType(NodeTypes.DOCUMENT_TYPE_NODE),
+    Utilities.isDocumentFragmentNode = Utilities.isNodeOfType(NodeTypes.DOCUMENT_FRAGMENT_NODE),
 
     Utilities.splitQName = function (qn) {
         var i = qn.indexOf(":");
@@ -4899,39 +4926,20 @@ var xpath = (typeof exports === 'undefined') ? {} : exports;
         return exports.select(e, doc, true);
     };
 
-    var isNodeLike = function (value) {
-        return value 
-            && typeof value.nodeType === "number" 
-            && Number.isInteger(value.nodeType)
-            && value.nodeType >= 1
-            && value.nodeType <= 11
-            && typeof value.nodeName === "string";
-    };
-
-    var isArrayOfNodes = function (value) {
-        return Array.isArray(value) && value.every(isNodeLike);
-    };
-
-    var isNodeOfType = function (type) {
-        return function (value) {
-            return isNodeLike(value) && value.nodeType === type;
-        };
-    };
-
     assign(
         exports,
         {
-            isNodeLike: isNodeLike,
-            isArrayOfNodes: isArrayOfNodes,
-            isElement: isNodeOfType(NodeTypes.ELEMENT_NODE),
-            isAttribute: isNodeOfType(NodeTypes.ATTRIBUTE_NODE),
-            isTextNode: isNodeOfType(NodeTypes.TEXT_NODE),
-            isCDATASection: isNodeOfType(NodeTypes.CDATA_SECTION_NODE),
-            isProcessingInstruction: isNodeOfType(NodeTypes.PROCESSING_INSTRUCTION_NODE),
-            isComment: isNodeOfType(NodeTypes.COMMENT_NODE),
-            isDocumentNode: isNodeOfType(NodeTypes.DOCUMENT_NODE),
-            isDocumentTypeNode: isNodeOfType(NodeTypes.DOCUMENT_TYPE_NODE),
-            isDocumentFragment: isNodeOfType(NodeTypes.DOCUMENT_FRAGMENT_NODE),
+            isNodeLike: Utilities.isNodeLike,
+            isArrayOfNodes: Utilities.isArrayOfNodes,
+            isElementNode: Utilities.isElementNode,
+            isAttributeNode: Utilities.isAttributeNode,
+            isTextNode: Utilities.isTextNode,
+            isCDATASectionNode: Utilities.isCDATASectionNode,
+            isProcessingInstructionNode: Utilities.isProcessingInstructionNode,
+            isCommentNode: Utilities.isCommentNode,
+            isDocumentNode: Utilities.isDocumentNode,
+            isDocumentTypeNode: Utilities.isDocumentTypeNode,
+            isDocumentFragmentNode: Utilities.isDocumentFragmentNode
         }
     );
     // end non-node wrapper


### PR DESCRIPTION
I've appended "Node" to the check function names. I've also made the incoming data accept `null`. I also noticed when renaming functions that there was already an `isAttribute()` under `Utilities`. I did a little refactor to unify all the similar code under `Utilities` to keep things all in one place.

Please let me know if there is anything else you'd like to see.