### PR TITLE
(fix): isArrayOfNodes input type not assignable to guarded type

### DIFF
--- a/xpath.d.ts
+++ b/xpath.d.ts
@@ -39,7 +39,7 @@ export function useNamespaces(namespaceMap: Record<string, string>): XPathSelect
 
 // Type guards to narrow down the type of the selected type of a returned Node object
 export function isNodeLike(value: SelectedValue): value is Node;
-export function isArrayOfNodes(value: SelectedValue): value is Node[];
+export function isArrayOfNodes(value: SelectReturnType): value is Node[];
 export function isElement(value: SelectedValue): value is Element;
 export function isAttribute(value: SelectedValue): value is Attr;
 export function isTextNode(value: SelectedValue): value is Text;


### PR DESCRIPTION
using isArrayOfNodes gives a warning that `Array<Node> | SelectedValue` is not assignable to `SelectedValue`. 
This doesn't make sense, since you'd be using this when calling `select`, which returns exactly that type.

Fixes #126 