### PR TITLE
Add more tests to ensure proper handling of undefined

### DIFF
--- a/test.js
+++ b/test.js
@@ -156,6 +156,54 @@ describe('xpath', () => {
             assert.strictEqual('JKR', xpath.selectWithResolver('//ns:field[@ns:type="author"]/text()', doc, resolver)[0].nodeValue);
         });
 
+        it('should select empty set with undefined xpath, using a resolver', () => {
+            var xml = '<book xmlns:testns="http://example.com/test"><testns:title>Harry Potter</testns:title><testns:field testns:type="author">JKR</testns:field></book>';
+            var doc = parseXml(xml);
+            var resolver = {
+                mappings: {
+                    'ns': 'http://example.com/test'
+                },
+                lookupNamespaceURI: function (prefix) {
+                    return this.mappings[prefix];
+                }
+            }
+            var nodes = xpath.selectWithResolver(undefined, doc, resolver);
+            assert.deepStrictEqual(nodes, []);
+
+            var node = xpath.selectWithResolver(undefined, doc, resolver, true);
+            assert.strictEqual(node, undefined);
+        });
+
+        it('should throw if undefined doc, using a resolver', () => {
+            var resolver = {
+                mappings: {
+                    'ns': 'http://example.com/test'
+                },
+                lookupNamespaceURI: function (prefix) {
+                    return this.mappings[prefix];
+                }
+            }
+            assert.throws(() => xpath.selectWithResolver(undefined, undefined, resolver));
+        });
+
+        it('should select empty set with undefined resolver', () => {
+            var xml = '<book xmlns:testns="http://example.com/test"><testns:title>Harry Potter</testns:title><testns:field testns:type="author">JKR</testns:field></book>';
+            var doc = parseXml(xml);
+            var resolver = {
+                mappings: {
+                    'ns': 'http://example.com/test'
+                },
+                lookupNamespaceURI: function (prefix) {
+                    return this.mappings[prefix];
+                }
+            }
+            var nodes = xpath.selectWithResolver(undefined, doc, undefined);
+            assert.deepStrictEqual(nodes, []);
+
+            var node = xpath.selectWithResolver(undefined, doc, undefined, true);
+            assert.strictEqual(node, undefined);
+        });
+
         it('should select with namespaces, using namespace mappings', () => {
             var xml = '<book xmlns:testns="http://example.com/test"><testns:title>Harry Potter</testns:title><testns:field testns:type="author">JKR</testns:field></book>';
             var doc = parseXml(xml);

--- a/xpath.d.ts
+++ b/xpath.d.ts
@@ -1,34 +1,42 @@
 /// <reference lib="dom" />
 
-export type SelectedValue = Node | string | number | boolean | null;
+export type ScalarValue = string | number | boolean;
 
-export type SelectReturnType = Array<Node> | SelectedValue;
-export type SelectSingleReturnType = SelectedValue;
+export type SelectReturnType = Array<Node> | ScalarValue;
+export type SelectSingleReturnType = ScalarValue | Node | undefined;
+
+type Nullable<T> = T | null | undefined;
 
 export interface XPathSelect {
+    (expression: Nullable<undefined>, node: Node): [];
+    (expression: Nullable<undefined>, node: Node, single: false): [];
     (expression: string, node: Node): SelectReturnType;
     (expression: string, node: Node, single: false): SelectReturnType;
-    (expression: string, node: Node, single: true): SelectSingleReturnType;
+    (expression: Nullable<string>, node: Node, single: true): SelectSingleReturnType;
 }
 
 /**
  * Evaluate an XPath expression against a DOM node.
  */
+export function select(expression: Nullable<undefined>, node: Node): [];
+export function select(expression: Nullable<undefined>, node: Node, single: false): [];
 export function select(expression: string, node: Node): SelectReturnType;
 export function select(expression: string, node: Node, single: false): SelectReturnType;
-export function select(expression: string, node: Node, single: true): SelectSingleReturnType;
+export function select(expression: Nullable<string>, node: Node, single: true): SelectSingleReturnType;
 
 /**
  * Evaluate an xpath expression against a DOM node, returning the first result only.
  */
-export function select1(expression: string, node: Node): SelectSingleReturnType;
+export function select1(expression: Nullable<string>, node: Node): SelectSingleReturnType;
 
 /**
  * Evaluate an XPath expression against a DOM node using a given namespace resolver.
  */
-export function selectWithResolver(expression: string, node: Node, resolver?: XPathNSResolver | null): SelectReturnType;
-export function selectWithResolver(expression: string, node: Node, resolver: XPathNSResolver | null, single: false): SelectReturnType;
-export function selectWithResolver(expression: string, node: Node, resolver: XPathNSResolver | null, single: true): SelectSingleReturnType;
+export function selectWithResolver(expression: Nullable<undefined>, node: Node, resolver?: Nullable<XPathNSResolver>): [];
+export function selectWithResolver(expression: Nullable<undefined>, node: Node, resolver: Nullable<XPathNSResolver>, single: false): [];
+export function selectWithResolver(expression: string, node: Node, resolver?: Nullable<XPathNSResolver>): SelectReturnType;
+export function selectWithResolver(expression: string, node: Node, resolver: Nullable<XPathNSResolver>, single: false): SelectReturnType;
+export function selectWithResolver(expression: string, node: Node, resolver: Nullable<XPathNSResolver>, single: true): SelectSingleReturnType;
 
 /**
  * Creates a `select` function that uses the given namespace prefix to URI mappings when evaluating queries.


### PR DESCRIPTION
When using this code over at `node-saml`, I found that we were sending `undefined` or `null` on occasion. I've added some tests, but changed no behavior, to validate what was actually happening internally. I then updated the TypeScript types to match the tests.

This PR focuses on minimal changes for correctness involving these new tests, so I didn't address any of the broader feedback on types.