### PR TITLE
Fix document fragment support as contextNode

### DIFF
--- a/xpath.js
+++ b/xpath.js
@@ -2193,7 +2193,7 @@ var xpath = (typeof exports === 'undefined') ? {} : exports;
             return nodes;
         }
 
-        var startNodes = locationPath.absolute ? [PathExpr.getRoot(xpc, nodes)] : nodes;
+        var startNodes = locationPath.absolute && nodes[0].nodeType !== NodeTypes.DOCUMENT_FRAGMENT_NODE ? [PathExpr.getRoot(xpc, nodes)] : nodes;
 
         return PathExpr.applySteps(locationPath.steps, xpc, startNodes);
     };
@@ -2536,7 +2536,7 @@ var xpath = (typeof exports === 'undefined') ? {} : exports;
         [NodeTypes.COMMENT_NODE],
         'comment()'
     );
-    // elements, attributes, text, cdata, PIs, comments, document nodes
+    // elements, attributes, text, cdata, PIs, comments, document, document-fragment nodes
     NodeTest.nodeTest = NodeTest.makeNodeTypeTest(
         NodeTest.NODE,
         [
@@ -2547,6 +2547,7 @@ var xpath = (typeof exports === 'undefined') ? {} : exports;
             NodeTypes.PROCESSING_INSTRUCTION_NODE,
             NodeTypes.COMMENT_NODE,
             NodeTypes.DOCUMENT_NODE,
+            NodeTypes.DOCUMENT_FRAGMENT_NODE
         ],
         'node()'
     );


### PR DESCRIPTION
This PR is a fix for #142.

As mentioned in the issue, the problem occurred when using ShadowRoot (document fragment) as the context node with absolute xpath.
Check in [PathExpr.applyLocationPath](https://github.com/goto100/xpath/blob/4c181e8affc8656283ac9fb017a32a909dbc1b90/xpath.js#L2196) prevent it to fetch the ownerDocument as, in the case of ShadowRoot, it doesn't have acces to the nodes in the document-fragment.

Further in the code, document-fragment were forgotten as node [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/createDocumentFragment#usage_notes) defines document-fragment as nodes.
> DocumentFragments are DOM [Node](https://developer.mozilla.org/en-US/docs/Web/API/Node) objects