### PR TITLE
If we have a HTML, we also want to allow no namespace prefixes

### DIFF
--- a/xpath.js
+++ b/xpath.js
@@ -4531,7 +4531,9 @@ var xpath = (typeof exports === 'undefined') ? {} : exports;
         // backward compatibility - no reliable way to detect whether the DOM is HTML, but
         // this library has been using this method up until now, so we will continue to use it
         // ONLY when using an XPathExpression
-        this.context.caseInsensitive = XPathExpression.detectHtmlDom(n);
+        const htmlDom = XPathExpression.detectHtmlDom(n);
+        this.context.caseInsensitive = htmlDom;
+        this.context.allowAnyNamespaceForNoPrefix = htmlDom;
 
         var result = this.xpath.evaluate(this.context);
 


### PR DESCRIPTION
The library already contains detection for a HTML and makes xpaths case insensitive in such cases. However, it also makes sense to do the same thing with the option to allow any namespace when no prefix is specified